### PR TITLE
Fixes KUBE_CONFIG in kube_env

### DIFF
--- a/kube_env
+++ b/kube_env
@@ -1,5 +1,5 @@
 export KUBE_MASTER=local
 export KUBE_MASTER_IP=#masterIP
 export KUBE_MASTER_URL=https://#masterIP
-export KUBECONFIG=/path/to/config
+export KUBE_CONFIG=/path/to/config
 export KUBE_TEST_REPO_LIST=/path/to/repo/repo_list.yaml


### PR DESCRIPTION
It should be KUBE_CONFIG instead of KUBECONFIG. This will prevent confusion in the future.