### PR TITLE
Adds --num-nodes=2 to ginkgo_args

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -59,7 +59,7 @@ E2E_RUN=hack/e2e.go
 RESULTS_DIR=$BASE_DIR/results
 mkdir -p $RESULTS_DIR
 
-ginkgo_args="--ginkgo.dryRun=${DRY_RUN:-false} "
+ginkgo_args="--num-nodes=2 --ginkgo.dryRun=${DRY_RUN:-false} "
 
 if [[ -n "$FOCUS" ]]
 then


### PR DESCRIPTION
Some tests require at least 2 nodes in order to run. By default, the argument is -1, and thus those tests are skipped.

Setting this argument will enable some tests.