### PR TITLE
Updated install script to use go 1.10

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -5,7 +5,7 @@ sudo apt-get update -y
 
 set -o errexit
 
-GO_VERSION=tip
+GO_VERSION="1.10"
 
 BASEDIR=$(dirname "${BASH_SOURCE}")
 WIN_E2E_KUBE_BRANCH="win_e2e_testing"


### PR DESCRIPTION
Kubernetes needs golang-1.10-go to work but using "tip" as the
version installs golang-1.9.3-go instead. This in turn causes
kubernetes to fail.