### PR TITLE
run_e2e: Adds defaul number of parallel test nodes

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -47,6 +47,7 @@ function get_tests_regex() {
 }
 
 export GINKGO_NO_COLOR=y
+export GINKGO_PARALLEL_NODES=12
 
 FOCUS="`get_tests_regex $FOCUS`"
 if [[ -n "$SKIP" ]]


### PR DESCRIPTION
Adds 12 as defaul number of parallel test nodes.