### PR TITLE
Adds node-os-distro=windows argument

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -61,7 +61,7 @@ E2E_RUN=hack/e2e.go
 RESULTS_DIR=$BASE_DIR/results
 mkdir -p $RESULTS_DIR
 
-ginkgo_args="--num-nodes=2 --ginkgo.dryRun=${DRY_RUN:-false} "
+ginkgo_args="--num-nodes=2 --node-os-distro=windows --ginkgo.dryRun=${DRY_RUN:-false} "
 
 if [[ -n "$FOCUS" ]]
 then


### PR DESCRIPTION
Some tests rely on the specified node OS distro. By default it is debian. This will be useful for skipping Windows-unrelated tests.