### PR TITLE
Changed local to skeleton

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -73,7 +73,7 @@ then
 fi
 
 e2e_args=("--")
-e2e_args+=("--provider=local")
+e2e_args+=("--provider=skeleton")
 e2e_args+=("-v")
 e2e_args+=("--test")
 e2e_args+=(--test_args="$ginkgo_args")


### PR DESCRIPTION
Changed the provider from "local" to "skeleton" for generalization. Skeleton can connect to any cluster provided, local will only connect to the local cluster.